### PR TITLE
Fix URL parsing to include query parameters

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -124,6 +124,7 @@ func (z *zeroDriver) ParseServerMethod(uri string) (server string, method string
 		if sep == -1 {
 			return "", "", fmt.Errorf("bad url: '%s'. no '/' found", uri)
 		}
+		return tmp[0]+"?"+tmp[1][:sep],tmp[1][sep:],nil
 		uri = tmp[0] + tmp[1][sep:]
 	}
 


### PR DESCRIPTION
zero-go 使用consul为服务注册时，如果传递tag参数，会丢失。